### PR TITLE
Fixed flaky test in LinkingTest.java

### DIFF
--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
@@ -56,7 +56,7 @@ public class LinkingTest extends JerseyTest {
 
         String order = response.readEntity(String.class);
 
-        // Order of JSON (links) elements is not guaranteed... I wonder how many flaky tests are because of this.
+        // Order of JSON (links) elements is not guaranteed.
         // Attempting to sort the elements from order and the expected str below
         JSONObject orderJSON = new JSONObject(order);
         JSONArray linkJSON = orderJSON.getJSONArray("links");
@@ -83,7 +83,8 @@ public class LinkingTest extends JerseyTest {
         orderJSON = orderJSON.put("links", listLinkJSONArray);
         order = orderJSON.toString();
 
-        // Changed the order of the expected links, now following lexicographically ascending
+        // Changed the order of the expected links, now following 
+        // lexicographically ascending
         JSONAssert.assertEquals("{id:'123',price:'1.99',links:["
                     + "{uri:'/',params:{rel:'root'},uriBuilder:{absolute:false},rel:'root',rels:['root']},"
                     + "{uri:'/orders/123',params:{rel:'self'},uriBuilder:{absolute:false},rel:'self',rels:['self']},"

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
@@ -25,8 +25,15 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.linking.integration.app.LinkingApplication;
 import org.glassfish.jersey.linking.integration.representations.OrderRequest;
 import org.glassfish.jersey.test.JerseyTest;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 
 public class LinkingTest extends JerseyTest {
 
@@ -48,10 +55,39 @@ public class LinkingTest extends JerseyTest {
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
 
         String order = response.readEntity(String.class);
+
+        // Order of JSON (links) elements is not guaranteed... I wonder how many flaky tests are because of this.
+        // Attempting to sort the elements from order and the expected str below
+        JSONObject orderJSON = new JSONObject(order);
+        JSONArray linkJSON = orderJSON.getJSONArray("links");
+
+        ArrayList<JSONObject> listLinkJSON = new ArrayList<JSONObject>();
+        for (int i = 0; i < linkJSON.length(); i++) {
+            listLinkJSON.add(linkJSON.getJSONObject(i));
+        }
+
+        listLinkJSON.sort((obj1, obj2) -> {
+            String strObj1 = "";
+            String strObj2 = "";
+            try {
+                strObj1 = obj1.get("uri").toString();
+                strObj2 = obj2.get("uri").toString();
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+            return strObj1.compareTo(strObj2);
+        });
+
+        // Convert the ArrayList back into a JSON Array.
+        JSONArray listLinkJSONArray = new JSONArray(listLinkJSON);
+        orderJSON = orderJSON.put("links", listLinkJSONArray);
+        order = orderJSON.toString();
+
+        // Changed the order of the expected links, now following lexicographically ascending
         JSONAssert.assertEquals("{id:'123',price:'1.99',links:["
+                    + "{uri:'/',params:{rel:'root'},uriBuilder:{absolute:false},rel:'root',rels:['root']},"
                     + "{uri:'/orders/123',params:{rel:'self'},uriBuilder:{absolute:false},rel:'self',rels:['self']},"
-                    + "{uri:'/payments/order/123',params:{rel:'pay'},uriBuilder:{absolute:false},rel:'pay',rels:['pay']},"
-                    + "{uri:'/',params:{rel:'root'},uriBuilder:{absolute:false},rel:'root',rels:['root']}"
+                    + "{uri:'/payments/order/123',params:{rel:'pay'},uriBuilder:{absolute:false},rel:'pay',rels:['pay']}"
                     + "]}",
                 order, true);
     }


### PR DESCRIPTION
# Flaky test found in `LinkingTest.java`
The test method `orderContainsProvidedLinks()` in `LinkingTest.java` is found to be flaky by NonDex, a tool developed by the University of Illinois Computer Science researchers to detect flaky test through running the test with different implementation of methods.

By running

```
mvn clean test -pl incubator/declarative-linking \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex -am \
    Dtest=org.glassfish.jersey.linking.integration.LinkingTest#orderContainsProvidedLinks \
    -Dsurefire.failIfNoSpecifiedTests=false 2>&1 | 
    tee mvn-test-$(date +%H-%M-%S).log
```

maven should complain that the test method fails, and this is reflected in the log:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.555 s <<< FAILURE! -- in org.glassfish.jersey.linking.integration.LinkingTest
[ERROR] org.glassfish.jersey.linking.integration.LinkingTest.orderContainsProvidedLinks -- Time elapsed: 2.256 s <<< FAILURE!
java.lang.AssertionError: 
links[0].params.rel
Expected: self
     got: pay
 ; links[0].rel
Expected: self
     got: pay
 ; links[0].rels[0]
Expected: self
     got: pay
 ; links[0].uri
Expected: /orders/123
     got: /payments/order/123
 ; links[1].params.rel
Expected: pay
     got: self
 ; links[1].rel
Expected: pay
     got: self
 ; links[1].rels[0]
Expected: pay
     got: self
 ; links[1].uri
Expected: /payments/order/123
     got: /orders/123

	at org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:417)
	at org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:394)
	at org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:336)
	at org.glassfish.jersey.linking.integration.LinkingTest.orderContainsProvidedLinks(LinkingTest.java:51)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   LinkingTest.orderContainsProvidedLinks:51 links[0].params.rel
Expected: self
     got: pay
 ; links[0].rel
Expected: self
     got: pay
 ; links[0].rels[0]
Expected: self
     got: pay
 ; links[0].uri
Expected: /orders/123
     got: /payments/order/123
 ; links[1].params.rel
Expected: pay
     got: self
 ; links[1].rel
Expected: pay
     got: self
 ; links[1].rels[0]
Expected: pay
     got: self
 ; links[1].uri
Expected: /payments/order/123
     got: /orders/123
```

which shows that the `links` array does have all the elements, but the ordering is not what the assert statement expects.


# Cause of flakiness
The flakiness is caused by the non-deterministic ordering of the elements in JSON array `links` in the `order` JSON returned by `response.readEntity(String.class);`. The test expects 3 links to be returned by the method call, and the method call does deliver. However, the ordering of those links is not guaranteed, and the assert statement asserts only one ordering. Thus, this causes the test to sometimes fail, even though technically `order` does contain the correct content for the test to pass.

# Solution
A straightforward solution to this root cause is sorting the JSON elements. The pull request implements the sorting by taking the links out of the JSON, sorting them, and inserting them back into the JSON object.

The test also re-arranged the link elements in the assert statement in lexicographically ascending order as this is the sorting order used above.